### PR TITLE
ci: skip git hooks on release

### DIFF
--- a/.github/workflows/version.pre-release.yml
+++ b/.github/workflows/version.pre-release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global user.name "Bump version - ${{ github.repository }} (by ${{ github.actor }})"
           git config --global user.email "${{ github.repository }}-version-bump@users.noreply.github.com"
-          npm run release:pre
+          npm run release:pre -- --no-verify
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/version.release.yml
+++ b/.github/workflows/version.release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global user.name "Bump version - ${{ github.repository }} (by ${{ github.actor }})"
           git config --global user.email "${{ github.repository }}-version-bump@users.noreply.github.com"
-          npm run release
+          npm run release -- --no-verify
 
       - name: Push changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
Skips git hooks for release workflows. Somehow `pre-commit` fails with Husky 7. Maybe setting up husky is skipped in CI environments due to using `npm ci`.