### PR TITLE
ci: use `main` branch for distribution channel `next`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
   push:
     branches:
       - main
-      - next
       - beta
       - alpha
       - '*.x'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,9 +1,9 @@
 branches:
-  - main
-  - next
-  - next-major
-  # Maintainence releases
+  # Maintenance releases
   - '+([0-9])?(.{+([0-9]),x}).x'
+  # Next
+  - name: main
+    channel: next
   # Prereleases
   - name: beta
     prerelease: true


### PR DESCRIPTION
Update configuration for `semantic-release` so that `main` uses distribution channel `next`.

This means that:
- branch `main` will be available at `x.x.x@next`
- branch `N.x` will be available at `N.x.x@latest`
- branch `beta` will be available at `x.x.x@beta`
- branch `alpha` will be available at `x.x.x@alpha`

which means that to release changes from `main` it must be merged to `N.x`. This seems to make sense, because as soon as the first `@latest` distribution channel should be available, there should be a corresponding `N.x` branch to maintain it.

At least that's what I hope^^